### PR TITLE
Docs changes for the new flows.

### DIFF
--- a/source/includes/_egress.md
+++ b/source/includes/_egress.md
@@ -179,7 +179,6 @@ curl https://api.onramp.ltd/rpc/send_funds_to_email                           \
   -H "Content-Type: application/json"                                         \
   -X POST -d '{ "fiat_amount"        : 3000
               , "fiat_currency"      : "EUR"
-              , "user_ready_url"     : "wwww.example.com"
               , "user_redirect_url"  : "www.example.com?user_redirected"
               , "offer_skin"         :
                   { "title" : "The Nice merchant"
@@ -218,7 +217,6 @@ curl https://api.onramp.ltd/rpc/send_funds_to_email                           \
 ```json
 { "fiat_amount"        : 3000
 , "fiat_currency"      : "EUR"
-, "user_ready_url"     : "www.example.com"
 , "user_redirect_url"  : "www.example.com?user_redirected"
 , "offer_skin"         :     
     { "title"      : "The Nice merchant"
@@ -272,7 +270,6 @@ Field             |   Type          | Description                              
 ----------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------| --------
 fiat_amount       | Integer         | Amount to be paid denominated in cents.                                                                                             | Yes
 fiat_currency     | String          | Currency identifier following the [ISO 4217 standard](https://en.wikipedia.org/wiki/ISO_4217). Valid values are `"EUR"` or `"USD"`. | Yes
-user_ready_url    | Url             | Merchant callback endpoint to notify user signed up and is ready to accept the payment. It should be a complete, well formed, url.  | No
 user_redirect_url | Url             | Where to redirect the user after the egress has been confirmed. It should be a complete, well formed, url.                          | Yes
 offer_skin        | Egress Skin     | Specify how the offer should be displayed to the user (It might not be shown in this flow).                                         | Yes
 billing_details   | Billing Details | User billing details. Please, notice how **not** all parameters inside this json object are required except `merchant_customer_id`. | Yes
@@ -314,24 +311,6 @@ player_level          | String      | Your internal player level. Something like
 member_since          | Date        | The date since that user is a member of yours.                        | No
 merchant_customer_id  | String      | The merchant customer id.                                             | Yes
 
-### Callback notifying about user registered or didn't do it before the expiring date
-
-Either once the user signs up with **ON/RAMP** or after an expiration time passes, **ON/RAMP** will notify the merchant about if they provided a valid `user_ready_url` parameter.
-
-
-- If user signed up, **ON/RAMP** will make a **POST** request to the provided callback with the following body:
-
-```json
-{ "message": "COMPLETED_REGISTRATION"
-}
-```
-
-- If user didn't sing up before expiration date, **ON/RAMP** will make a **POST** request to the provided callback with the following body:
-
-```json
-{ "message": "CANCELLED_WITHDRAWAL"
-}
-```
 
 ### Response JSON Fields
 
@@ -339,21 +318,11 @@ Field       | Type    | Description
 ----------- | ------- | -----------
 invoice_id  | String  | Internal **ON/RAMP**'s Invoice Identifier.
 description | String  | Description about the invoice. Might be empty.
-message     | String  | **MIGHT NOT BE PRESENT**: Additional status if user is not registered. If user is not registered its value will be "WAITING_FOR_USER_REGISTRATION"
-
-**Note**: If `user_ready_url` is provided and user inputs a not registered email, **ON/RAMP** will respond with the attached response.
-
-> Response JSON
-
-```json
-{ "invoice_id" : "cde6f458-8754-4ffe-81a9-77c6d05a5540"
-, "description": {}
-, "message": "WAITING_FOR_USER_REGISTRATION"
-}
-```
+message     | String  | **MIGHT NOT BE PRESENT**: Additional status if user is not registered.
 
 
-**Note**: If no `user_ready_url` is provided and user inputs a not registered email, **ON/RAMP** will respond with the attached response.
+
+**Note**: If `accept_unregister_user` is set to `false` and user inputs a not registered email, **ON/RAMP** will respond with the attached response.
 
 > Response JSON
 
@@ -366,7 +335,7 @@ message     | String  | **MIGHT NOT BE PRESENT**: Additional status if user is n
 }
 ```
 
-In that case, merchant should inform the user about this email being invalid and show a link to sign up with **ON/RAMP** at [https://onrampwallet.com](https://onrampwallet.com).
+In that case, merchant should inform the user about email account being invalid and show a link to sign up with **ON/RAMP** at [https://onrampwallet.com](https://onrampwallet.com).
 
 
 ## Approve or Reject User Email Egress Invoice (User email flow)

--- a/source/includes/_egress.md
+++ b/source/includes/_egress.md
@@ -3,9 +3,7 @@
 Any of the endpoints below will return:
 
 - **200** http status if everything was ok.
-- **400** http status if some parameters were invalid (It may specify exactly which ones.
-+ **400** http status if some parameters were invalid (It may specify exactly which ones.)
-
+- **400** http status if some parameters were invalid (It may specify exactly which ones).
 - **500** http status if something unexpected happened on ON/RAMP's server.
 
 ## Create Egress Invoice (App redirection flow)
@@ -107,23 +105,23 @@ curl https://api.onramp.ltd/rpc/create_egress_invoice                     \
 
 ### Request JSON Fields
 
-Field             |   Type          | Description
------------------ | --------------- | -----------
-fiat_amount       | Integer         | Eur amount to be paid denominated in cents.
-fiat_currency     | String          | The constant `"EUR"`.
-payment_ack_url   | String          | Merchant callback endpoint to confirm egress transaction. It should be a complete, well formed, url.
-user_redirect_url | String          | Where to redirect the user after the egress has been confirmed. It should be a complete, well formed, url.
-timeout_in_sec    | Integer         | When to expire the link if unused.
-offer_skin        | Egress Skin     | Specify how the offer should be displayed to the user.
-billing_details   | Billing Details | User billing details. Please, notice how **not** all parameters inside this json object are required except `merchant_customer_id`.
+Field             |   Type          | Description                                                                                                                          | Required 
+----------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------ | --------
+fiat_amount       | Integer         | Eur amount to be paid denominated in cents.                                                                                          | Yes
+fiat_currency     | String          | `"EUR"` or `"USD"`, depending what is available on the merchants account settings.                                                   | Yes 
+payment_ack_url   | String          | Merchant callback endpoint to confirm egress transaction. It should be a complete, well formed, url.                                 | Yes
+user_redirect_url | String          | Where to redirect the user after the egress has been confirmed. It should be a complete, well formed, url.                           | Yes
+timeout_in_sec    | Integer         | When to expire the link if unused.                                                                                                   | Yes
+offer_skin        | Egress Skin     | Specify how the offer should be displayed to the user.                                                                               | Yes
+billing_details   | Billing Details | User billing details. Please, notice how **not** all parameters inside this json object are required except `merchant_customer_id`.  | Yes
 
 ### Egress Skin
 
-Field             |   Type      | Description
------------------ | ----------- | -----------
-title             | string      | Short string containing merchant's or redemption's name.
-image             | url         | image to stylized the offer.
-description       | string      | A text explaining what the user is redeeming.
+Field             |   Type      | Description                                               | Required
+----------------- | ----------- | --------------------------------------------------------- | --------
+title             | string      | Short string containing merchant's or redemption's name.  | Yes
+image             | url         | image to stylized the offer.                              | Yes
+description       | string      | A text explaining what the user is redeeming.             | Yes
 
 ### Billing Details
 
@@ -150,7 +148,6 @@ address_doc_reference | String      | A unique id of the address document refere
 player_level          | String      | Your internal player level. Something like New, Normal, VIP, ...      | No
 member_since          | Date        | The date since that user is a member of yours.                        | No
 merchant_customer_id  | String      | The merchant customer id.                                             | Yes
-
 
 
 ### Callback Egress Invoice
@@ -181,6 +178,7 @@ curl https://api.onramp.ltd/rpc/send_funds_to_email                           \
   -H "Content-Type: application/json"                                         \
   -X POST -d '{ "fiat_amount"        : 3000
               , "fiat_currency"      : "EUR"
+              , "user_ready_url"     : "wwww.example.com"
               , "user_redirect_url"  : "www.example.com?user_redirected"
               , "offer_skin"         :
                   { "title" : "The Nice merchant"
@@ -219,6 +217,7 @@ curl https://api.onramp.ltd/rpc/send_funds_to_email                           \
 ```json
 { "fiat_amount"        : 3000
 , "fiat_currency"      : "EUR"
+, "user_ready_url"     : "www.example.com"
 , "user_redirect_url"  : "www.example.com?user_redirected"
 , "offer_skin"         :     
     { "title"      : "The Nice merchant"
@@ -258,6 +257,7 @@ curl https://api.onramp.ltd/rpc/send_funds_to_email                           \
 ```json
 { "invoice_id" : "cde6f458-8754-4ffe-81a9-77c6d05a5540"
 , "description": {}
+, "message": ""
 }
 ```
 
@@ -267,22 +267,23 @@ curl https://api.onramp.ltd/rpc/send_funds_to_email                           \
 
 ### Request JSON Fields
 
-Field             |   Type          | Description
------------------ | --------------- | ---------
-fiat_amount       | Integer         | Eur amount to be paid denominated in cents.
-fiat_currency     | String          | The constant `"EUR"`.
-user_redirect_url | String          | Where to redirect the user after the egress has been confirmed. It should be a complete, well formed, url.
-offer_skin        | Egress Skin     | Specify how the offer should be displayed to the user (It might not be shown in this flow).
-billing_details   | Billing Details | User billing details. Please, notice how **not** all parameters inside this json object are required except `merchant_customer_id`.
-onramp_user_email | String          | The email the user has registered with ON/RAMP.
+Field             |   Type          | Description                                                                                                                         | Required
+----------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------| --------
+fiat_amount       | Integer         | Eur amount to be paid denominated in cents.                                                                                         | Yes
+fiat_currency     | String          | `"EUR"` or `"USD"`, depending what is available on the merchants account settings.                                                  | Yes
+user_ready_url    | String          | Merchant callback endpoint to notify user signed up and is ready to accept the payment. It should be a complete, well formed, url.  | No
+user_redirect_url | String          | Where to redirect the user after the egress has been confirmed. It should be a complete, well formed, url.                          | Yes
+offer_skin        | Egress Skin     | Specify how the offer should be displayed to the user (It might not be shown in this flow).                                         | Yes
+billing_details   | Billing Details | User billing details. Please, notice how **not** all parameters inside this json object are required except `merchant_customer_id`. | Yes
+onramp_user_email | String          | The email the user has registered with ON/RAMP.                                                                                     | Yes
 
 ### Egress Skin
 
-Field             |   Type      | Description
------------------ | ----------- | -----------
-title             | string      | Short string containing merchant's or redemption's name.
-image             | url         | image to stylized the offer.
-description       | string      | A text explaining what the user is redeeming.
+Field             |   Type      | Description                                               | Required
+----------------- | ----------- | --------------------------------------------------------- | --------
+title             | string      | Short string containing merchant's or redemption's name.  | Yes
+image             | url         | image to stylized the offer.                              | Yes
+description       | string      | A text explaining what the user is redeeming.             | Yes
 
 ### Billing Details
 
@@ -310,8 +311,46 @@ player_level          | String      | Your internal player level. Something like
 member_since          | Date        | The date since that user is a member of yours.                        | No
 merchant_customer_id  | String      | The merchant customer id.                                             | Yes
 
+### Callback notifying about user registered or didn't do it before the expiring date
 
-**Note**: If user inputs an invalid email, **ON/RAMP** will respond with the attached response.
+Either once the user signs up with **ON/RAMP** or after some defined expiration time passes, **ON/RAMP** will notify the merchant about if they provided a valid `user_ready_url` parameter.
+
+
+- If user signed up, **ON/RAMP** will make a **POST** request to the provided callback with the following body:
+
+```json
+{ "message": "COMPLETED_REGISTRATION"
+}
+```
+
+- If user didn't sing up before expiration date, **ON/RAMP** will make a **POST** request to the provided callback with the following body:
+
+```json
+{ "message": "CANCELLED_WITHDRAWAL"
+}
+```
+
+### Response JSON Fields
+
+Field       | Type    | Description
+----------- | ------- | -----------
+invoice_id  | String  | Internal **ON/RAMP**'s Invoice Identifier.
+description | String  | Description about the invoice. Might be empty.
+message     | String  | **MIGHT NOT BE PRESENT**: Additional status if user is not registered. If user is not registered its value will be "WAITING_FOR_USER_REGISTRATION"
+
+**Note**: If `user_ready_url` is provided and user inputs a not registered email, **ON/RAMP** will respond with the attached response.
+
+> Response JSON
+
+```json
+{ "invoice_id" : "cde6f458-8754-4ffe-81a9-77c6d05a5540"
+, "description": {}
+, "message": "WAITING_FOR_USER_REGISTRATION"
+}
+```
+
+
+**Note**: If no `user_ready_url` is provided and user inputs a not registered email, **ON/RAMP** will respond with the attached response.
 
 > Response JSON
 
@@ -324,7 +363,7 @@ merchant_customer_id  | String      | The merchant customer id.                 
 }
 ```
 
-You should inform the user about this email being invalid and show a link to sign up with **ON/RAMP** at [https://onrampwallet.com](https://onrampwallet.com).
+In that case, merchant should inform the user about this email being invalid and show a link to sign up with **ON/RAMP** at [https://onrampwallet.com](https://onrampwallet.com).
 
 
 ## Approve or Reject User Email Egress Invoice (User email flow)

--- a/source/includes/_egress.md
+++ b/source/includes/_egress.md
@@ -107,10 +107,10 @@ curl https://api.onramp.ltd/rpc/create_egress_invoice                     \
 
 Field             |   Type          | Description                                                                                                                          | Required 
 ----------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------ | --------
-fiat_amount       | Integer         | Eur amount to be paid denominated in cents.                                                                                          | Yes
-fiat_currency     | String          | `"EUR"` or `"USD"`, depending what is available on the merchants account settings.                                                   | Yes 
-payment_ack_url   | String          | Merchant callback endpoint to confirm egress transaction. It should be a complete, well formed, url.                                 | Yes
-user_redirect_url | String          | Where to redirect the user after the egress has been confirmed. It should be a complete, well formed, url.                           | Yes
+fiat_amount       | Integer         | Amount to be paid denominated in cents.                                                                                              | Yes
+fiat_currency     | String          | Currency identifier following the [ISO 4217 standard](https://en.wikipedia.org/wiki/ISO_4217). Valid values are `"EUR"` or `"USD"`.  | Yes
+payment_ack_url   | Url             | Merchant callback endpoint to confirm egress transaction. It should be a complete, well formed, url.                                 | Yes
+user_redirect_url | Url             | Where to redirect the user after the egress has been confirmed. It should be a complete, well formed, url.                           | Yes
 timeout_in_sec    | Integer         | When to expire the link if unused.                                                                                                   | Yes
 offer_skin        | Egress Skin     | Specify how the offer should be displayed to the user.                                                                               | Yes
 billing_details   | Billing Details | User billing details. Please, notice how **not** all parameters inside this json object are required except `merchant_customer_id`.  | Yes
@@ -119,9 +119,9 @@ billing_details   | Billing Details | User billing details. Please, notice how *
 
 Field             |   Type      | Description                                               | Required
 ----------------- | ----------- | --------------------------------------------------------- | --------
-title             | string      | Short string containing merchant's or redemption's name.  | Yes
-image             | url         | image to stylized the offer.                              | Yes
-description       | string      | A text explaining what the user is redeeming.             | Yes
+title             | String      | Short string containing merchant's or redemption's name.  | Yes
+image             | Url         | Image to stylize the offer.                               | Yes
+description       | String      | A text explaining what the user is redeeming.             | Yes
 
 ### Billing Details
 
@@ -164,7 +164,7 @@ pausing the user payment and prompting manual intervention, potentially delaying
 Field       | Type    | Description
 ----------- | ------- | -----------
 invoice_id  | String  | Internal **ON/RAMP**'s Invoice Identifier.
-invoice_url | String  | Url where to redirect user.
+invoice_url | Url     | Url where to redirect user.
 
 
 ## Create Egress Invoice (User email flow)
@@ -269,10 +269,10 @@ curl https://api.onramp.ltd/rpc/send_funds_to_email                           \
 
 Field             |   Type          | Description                                                                                                                         | Required
 ----------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------| --------
-fiat_amount       | Integer         | Eur amount to be paid denominated in cents.                                                                                         | Yes
-fiat_currency     | String          | `"EUR"` or `"USD"`, depending what is available on the merchants account settings.                                                  | Yes
-user_ready_url    | String          | Merchant callback endpoint to notify user signed up and is ready to accept the payment. It should be a complete, well formed, url.  | No
-user_redirect_url | String          | Where to redirect the user after the egress has been confirmed. It should be a complete, well formed, url.                          | Yes
+fiat_amount       | Integer         | Amount to be paid denominated in cents.                                                                                             | Yes
+fiat_currency     | String          | Currency identifier following the [ISO 4217 standard](https://en.wikipedia.org/wiki/ISO_4217). Valid values are `"EUR"` or `"USD"`. | Yes
+user_ready_url    | Url             | Merchant callback endpoint to notify user signed up and is ready to accept the payment. It should be a complete, well formed, url.  | No
+user_redirect_url | Url             | Where to redirect the user after the egress has been confirmed. It should be a complete, well formed, url.                          | Yes
 offer_skin        | Egress Skin     | Specify how the offer should be displayed to the user (It might not be shown in this flow).                                         | Yes
 billing_details   | Billing Details | User billing details. Please, notice how **not** all parameters inside this json object are required except `merchant_customer_id`. | Yes
 onramp_user_email | String          | The email the user has registered with ON/RAMP.                                                                                     | Yes
@@ -281,9 +281,9 @@ onramp_user_email | String          | The email the user has registered with ON/
 
 Field             |   Type      | Description                                               | Required
 ----------------- | ----------- | --------------------------------------------------------- | --------
-title             | string      | Short string containing merchant's or redemption's name.  | Yes
-image             | url         | image to stylized the offer.                              | Yes
-description       | string      | A text explaining what the user is redeeming.             | Yes
+title             | String      | Short string containing merchant's or redemption's name.  | Yes
+image             | Url         | image to stylize the offer.                               | Yes
+description       | String      | A text explaining what the user is redeeming.             | Yes
 
 ### Billing Details
 
@@ -313,7 +313,7 @@ merchant_customer_id  | String      | The merchant customer id.                 
 
 ### Callback notifying about user registered or didn't do it before the expiring date
 
-Either once the user signs up with **ON/RAMP** or after some defined expiration time passes, **ON/RAMP** will notify the merchant about if they provided a valid `user_ready_url` parameter.
+Either once the user signs up with **ON/RAMP** or after an expiration time passes, **ON/RAMP** will notify the merchant about if they provided a valid `user_ready_url` parameter.
 
 
 - If user signed up, **ON/RAMP** will make a **POST** request to the provided callback with the following body:

--- a/source/includes/_egress.md
+++ b/source/includes/_egress.md
@@ -105,7 +105,7 @@ curl https://api.onramp.ltd/rpc/create_egress_invoice                     \
 
 ### Request JSON Fields
 
-Field             |   Type          | Description                                                                                                                          | Required 
+Field             |   Type          | Description                                                                                                                          | Required
 ----------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------ | --------
 fiat_amount       | Integer         | Amount to be paid denominated in cents.                                                                                              | Yes
 fiat_currency     | String          | Currency identifier following the [ISO 4217 standard](https://en.wikipedia.org/wiki/ISO_4217). Valid values are `"EUR"` or `"USD"`.  | Yes
@@ -114,6 +114,7 @@ user_redirect_url | Url             | Where to redirect the user after the egres
 timeout_in_sec    | Integer         | When to expire the link if unused.                                                                                                   | Yes
 offer_skin        | Egress Skin     | Specify how the offer should be displayed to the user.                                                                               | Yes
 billing_details   | Billing Details | User billing details. Please, notice how **not** all parameters inside this json object are required except `merchant_customer_id`.  | Yes
+cancel_callback   | Url             | Merchant callback endpoint to be called when an egress payment couldn't be completed                                                 | No
 
 ### Egress Skin
 
@@ -276,7 +277,9 @@ user_redirect_url | Url             | Where to redirect the user after the egres
 offer_skin        | Egress Skin     | Specify how the offer should be displayed to the user (It might not be shown in this flow).                                         | Yes
 billing_details   | Billing Details | User billing details. Please, notice how **not** all parameters inside this json object are required except `merchant_customer_id`. | Yes
 onramp_user_email | String          | The email the user has registered with ON/RAMP.                                                                                     | Yes
-
+cancel_callback   | Url             | Merchant callback endpoint to be called when an egress payment couldn't be completed                                                | No
+accept_unregister_user | Bool       | If `false` egress to users without an **ON/RAMP** account at the moment the egress was created will be immediately rejected. Defaults to `false` | No  
+required_merchant_confirmation | Bool | If `true`, **ON/RAMP** will wait for a merchant confirmation before releasing the funds. Defaults to `true`                       | No
 ### Egress Skin
 
 Field             |   Type      | Description                                               | Required

--- a/source/includes/_ingress.md
+++ b/source/includes/_ingress.md
@@ -108,10 +108,10 @@ curl https://api.onramp.ltd/rpc/create_ingress_invoice                          
 
 Field             |   Type          | Description                                                                                                                          | Required
 ----------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------ | --------
-fiat_amount       | Integer         | Eur amount to be paid denominated in cents .                                                                                         | Yes
-fiat_currency     | String          | `"EUR"` or `"USD"`, depending what is available on the merchants account settings.                                                   | Yes
-payment_ack_url   | String          | Merchant callback endpoint to confirm ingress transaction. It should be a complete, well formed, url.                                | Yes
-user_redirect_url | String          | Where to redirect the user after a successful payment. It should be a complete, well formed, url.                                    | Yes
+fiat_amount       | Integer         | Amount to be paid denominated in cents .                                                                                             | Yes
+fiat_currency     | String          | Currency identifier following the [ISO 4217 standard](https://en.wikipedia.org/wiki/ISO_4217). Valid values are `"EUR"` or `"USD"`.  | Yes
+payment_ack_url   | Url             | Merchant callback endpoint to confirm ingress transaction. It should be a complete, well formed, url.                                | Yes
+user_redirect_url | Url             | Where to redirect the user after a successful payment. It should be a complete, well formed, url.                                    | Yes
 timeout_in_sec    | Integer         | When to expire the link if unused.                                                                                                   | Yes
 offer_skin        | Ingress Skin    | Specify how the offer should be displayed to the user.                                                                               | Yes
 billing_details   | Billing Details | User billing details. Please, notice how **not** all parameters inside this json object are required except `merchant_customer_id`.  | Yes
@@ -121,7 +121,7 @@ billing_details   | Billing Details | User billing details. Please, notice how *
 Field             |   Type      | Description                                            | Required
 ----------------- | ----------- | ------------------------------------------------------ | --------
 title             | String      | Short string containing merchant's or product's name.  | Yes
-image             | Url         | image to stylized the offer.                           | Yes
+image             | Url         | image to stylize the offer.                            | Yes
 description       | String      | A text explaining what the user is purchasing.         | Yes
 
 ### Billing Details
@@ -165,4 +165,4 @@ pausing the user payment and prompting manual intervention, potentially delaying
 Field       | Type    | Description
 ----------- | ------- | -----------
 invoice_id  | String  | Internal **ON/RAMP**'s Invoice Identifier.
-invoice_url | String  | Url where to redirect user.
+invoice_url | Url     | Url where to redirect user.

--- a/source/includes/_ingress.md
+++ b/source/includes/_ingress.md
@@ -115,6 +115,7 @@ user_redirect_url | Url             | Where to redirect the user after a success
 timeout_in_sec    | Integer         | When to expire the link if unused.                                                                                                   | Yes
 offer_skin        | Ingress Skin    | Specify how the offer should be displayed to the user.                                                                               | Yes
 billing_details   | Billing Details | User billing details. Please, notice how **not** all parameters inside this json object are required except `merchant_customer_id`.  | Yes
+cancel_callback   | Url             | Merchant callback endpoint to be called when an ingress payment couldn't be completed                                                | No
 
 ### Ingress Skin
 

--- a/source/includes/_ingress.md
+++ b/source/includes/_ingress.md
@@ -3,8 +3,7 @@
 Any of the endpoints below will return:
 
 - **200** http status if everything was ok.
-- **400** http status if some parameters were invalid (It may specify exactly which ones.
-+ **400** http status if some parameters were invalid (It may specify exactly which ones.)
+- **400** http status if some parameters were invalid (It may specify exactly which ones).
 - **500** http status if something unexpected happened on ON/RAMP's server.
 
 ## Create Ingress Invoice
@@ -107,23 +106,23 @@ curl https://api.onramp.ltd/rpc/create_ingress_invoice                          
 
 ### Request JSON Fields
 
-Field             |   Type          | Description
------------------ | --------------- | -----------
-fiat_amount       | Integer         | Eur amount to be paid denominated in cents .
-fiat_currency     | String          | The constant `"EUR"`.
-payment_ack_url   | String          | Merchant callback endpoint to confirm ingress transaction. It should be a complete, well formed, url.
-user_redirect_url | String          | Where to redirect the user after a successful payment. It should be a complete, well formed, url.
-timeout_in_sec    | Integer         | When to expire the link if unused.
-offer_skin        | Ingress Skin    | Specify how the offer should be displayed to the user.
-billing_details   | Billing Details | User billing details. Please, notice how **not** all parameters inside this json object are required except `merchant_customer_id`.
+Field             |   Type          | Description                                                                                                                          | Required
+----------------- | --------------- | ------------------------------------------------------------------------------------------------------------------------------------ | --------
+fiat_amount       | Integer         | Eur amount to be paid denominated in cents .                                                                                         | Yes
+fiat_currency     | String          | `"EUR"` or `"USD"`, depending what is available on the merchants account settings.                                                   | Yes
+payment_ack_url   | String          | Merchant callback endpoint to confirm ingress transaction. It should be a complete, well formed, url.                                | Yes
+user_redirect_url | String          | Where to redirect the user after a successful payment. It should be a complete, well formed, url.                                    | Yes
+timeout_in_sec    | Integer         | When to expire the link if unused.                                                                                                   | Yes
+offer_skin        | Ingress Skin    | Specify how the offer should be displayed to the user.                                                                               | Yes
+billing_details   | Billing Details | User billing details. Please, notice how **not** all parameters inside this json object are required except `merchant_customer_id`.  | Yes
 
 ### Ingress Skin
 
-Field             |   Type      | Description
------------------ | ----------- | -----------
-title             | String      | Short string containing merchant's or product's name.
-image             | Url         | image to stylized the offer.
-description       | String      | A text explaining what the user is purchasing.
+Field             |   Type      | Description                                            | Required
+----------------- | ----------- | ------------------------------------------------------ | --------
+title             | String      | Short string containing merchant's or product's name.  | Yes
+image             | Url         | image to stylized the offer.                           | Yes
+description       | String      | A text explaining what the user is purchasing.         | Yes
 
 ### Billing Details
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -58,10 +58,11 @@ There are currently two different supported flows for egress:
 
 #### User email flow
 
-1. Prerequisite: User will need to have an account in **ON/RAMP**.
 1. Merchant [creates a user email egress invoice](#create-egress-invoice-user-email-flow).
 1. **ON/RAMP** prepares the payment and returns a reference of it for the merchant to later approve it or reject it.
-1. Before the [invoice expires](#invoice-expiration), whenever merchants want to, they can [approve or reject the process](#approve-or-reject-user-email-egress-invoice-user-email-flow). At that moment, **ON/RAMP** will finish the process, move the funds to users balance if needed and return a success or failure.
+1. **ON/RAMP** also returns if the user exists (and so the process can be immediately approved) or if the user does not exist (and so merchant needs to wait for the user to sign up with **ON/RAMP**).
+1. If the user didn't exist, once the user signs up in **ON/RAMP**, a callback notifying the merchant about it will be sent from **ON/RAMP**.
+1. Before the [invoice expires](#invoice-expiration), whenever merchants want to (and after receiving the mentioned callback if it was needed), they can [approve or reject the process](#approve-or-reject-user-email-egress-invoice-user-email-flow). At that moment, **ON/RAMP** will finish the process, move the funds to users balance if needed and return a success or failure.
 1. The user will see the outcome of the process in the **ON/RAMP** wallet.
 
 # Calling **ON/RAMP** API endpoints.

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -51,19 +51,35 @@ There are currently two different supported flows for egress:
 #### App redirection flow
 
 1. Merchant [creates an egress invoice url](#create-egress-invoice-app-redirection-flow).
+
 1. Merchant redirects user to the egress invoice url.
-1. **ON/RAMP** handles the payment.
-1. If the payment succeed, **ON/RAMP** will [call back the merchant to either confirm the egress transaction or to abort it](#callback-egress-invoice). If merchants confirms, the egress payment will be considered fulfilled, otherwise, it will be considered as failed.
-1. The user will see the outcome of the process in the **ON/RAMP** wallet.
+
+1. **ON/RAMP** gathers required user's data and consent. If the payment is not feasible or was rejected
+   by the user, it will fail at this point.
+
+1. **ON/RAMP** [calls back the merchant](#callback-egress-invoice) returning a reference for execution.
+
+1. Merchants accepts, rejects or postpones the egress payment.
+
+1. If postponed, merchant will have up to 3 days to [accept or reject it](#mark_operation).
+
+1. If after 3 days merchant neither accepts nor reject the egress payment it will automatically get rejected.
 
 #### User email flow
 
 1. Merchant [creates a user email egress invoice](#create-egress-invoice-user-email-flow).
-1. **ON/RAMP** prepares the payment and returns a reference of it for the merchant to later approve it or reject it.
-1. **ON/RAMP** also returns if the user exists (and so the process can be immediately approved) or if the user does not exist (and so merchant needs to wait for the user to sign up with **ON/RAMP**).
-1. If the user didn't exist, once the user signs up in **ON/RAMP**, a callback notifying the merchant about it will be sent from **ON/RAMP**.
-1. Before the [invoice expires](#invoice-expiration), whenever merchants want to (and after receiving the mentioned callback if it was needed), they can [approve or reject the process](#approve-or-reject-user-email-egress-invoice-user-email-flow). At that moment, **ON/RAMP** will finish the process, move the funds to users balance if needed and return a success or failure.
-1. The user will see the outcome of the process in the **ON/RAMP** wallet.
+
+1. **ON/RAMP** prepares the payment and returns a reference for the merchant to later accept it or reject it.
+   Merchants can decide whether accept any user or only users previously registered on **ON/RAMP**. If only
+   previously registered users was requested but the user hast not already registered, or the payment is not feasible, it will fail at this point, otherwise it will return a reference to the Merchant to accept or reject the payment.
+
+1. Merchants will have up to 3 days to accept or reject the payment, unless the option `required_merchant_confirmation`
+   is set to `false`, in which case it will be always considered accepted by the merchant.
+
+1. If the user is not already registered, **ON/RAMP** will send emails to the user requesting his/her registration.
+   Users will have up to 3 days to register, otherwise the egress payment will get cancel **even if it was previously
+   accepted by the merchant**.
+
 
 # Calling **ON/RAMP** API endpoints.
 

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -58,7 +58,7 @@ There are currently two different supported flows for egress:
 
 #### User email flow
 
-1. Prerequisite: User will need to have an account in **ON/RAMP** with KYC verified.
+1. Prerequisite: User will need to have an account in **ON/RAMP**.
 1. Merchant [creates a user email egress invoice](#create-egress-invoice-user-email-flow).
 1. **ON/RAMP** prepares the payment and returns a reference of it for the merchant to later approve it or reject it.
 1. Before the [invoice expires](#invoice-expiration), whenever merchants want to, they can [approve or reject the process](#approve-or-reject-user-email-egress-invoice-user-email-flow). At that moment, **ON/RAMP** will finish the process, move the funds to users balance if needed and return a success or failure.


### PR DESCRIPTION
This PR adds some small changes over @yowlu  https://github.com/on-ramp/api-doc/pull/13 .

- Describes the changes to the send funds to email flow.

- Update outdated description of the redirection flow.

- Add missing fields

- Cancel callbacks are not mentioned on the flow overview, but on the field descriptions. Notice that a merchant is free to use either rely on those callbacks, to poll the `op_status` endpoint or consult the backoffice.

     - A bit off topic but, the ack callback used to be enough to know whether something would be considered executed or not, but now that we allow egress to unregistered users, they might fail after the merchant's acceptance if the user didn't open an account.... so probably it is a very good idea in a near future to add a "completed callback".

     - A bit off topic but, We probably need to improve the `op_status` endpoint to show more info like whether the reason an operation is still waiting is because the user didn't register yet (the backoffice panel is made out of the same endpoint, so only need to change one)
