### PR TITLE
Add docs about QR code on ingress and egress responses, Fix problem on dockerfile

### DIFF
--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1,6 +1,7 @@
 FROM ruby:2.5.1
 
-RUN apt-get update && curl -sL https://deb.nodesource.com/setup_10.x | bash - \
+RUN curl -sL https://deb.nodesource.com/setup_10.x | bash \
+&& apt-get update \ 
 && apt-get install -y nodejs \
 && apt-get clean && rm -rf /var/lib/apt/lists/*
 

--- a/deploy/docker/Dockerfile
+++ b/deploy/docker/Dockerfile
@@ -1,6 +1,7 @@
 FROM ruby:2.5.1
 
-RUN apt-get update && apt-get install -y nodejs \
+RUN apt-get update && curl -sL https://deb.nodesource.com/setup_10.x | bash - \
+&& apt-get install -y nodejs \
 && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 COPY ./Gemfile /usr/src/app/

--- a/source/includes/_egress.md
+++ b/source/includes/_egress.md
@@ -96,6 +96,7 @@ curl https://api.onramp.ltd/rpc/create_egress_invoice                     \
 ```json
 { "invoice_id": "cde6f458-8754-4ffe-81a9-77c6d05a5540"
 , "invoice_url": "https://wallet.onramp.ltd/egressing?reference=cde6f458-8754-4ffe-81a9-77c6d05a5540"
+, "invoice_url_qr": "https://api.onramp.ltd/qr_encode/68747470733a2f2f73746167652d77616c6c65742e6f6e72616d702e6c74642f696e6772657373696e673f7265666572656e63653d65646361623662342d343464342d343763652d396261322d366636656562626661313567"
 }
 ```
 
@@ -163,10 +164,11 @@ pausing the user payment and prompting manual intervention, potentially delaying
 
 ### Response JSON Fields
 
-Field       | Type    | Description
------------ | ------- | -----------
-invoice_id  | String  | Internal **ON/RAMP**'s Invoice Identifier.
-invoice_url | Url     | Url where to redirect user.
+Field          | Type    | Description
+-------------- | ------- | -----------
+invoice_id     | String  | Internal **ON/RAMP**'s Invoice Identifier.
+invoice_url    | Url     | Url where to redirect user.
+invoice_url_qr | Url     | Url where to redirect user in QR code format.
 
 
 ## Create Egress Invoice (User email flow)

--- a/source/includes/_egress.md
+++ b/source/includes/_egress.md
@@ -168,7 +168,7 @@ Field          | Type    | Description
 -------------- | ------- | -----------
 invoice_id     | String  | Internal **ON/RAMP**'s Invoice Identifier.
 invoice_url    | Url     | Url where to redirect user.
-invoice_url_qr | Url     | Url where to redirect user in QR code format.
+invoice_url_qr | Url     | Source Url for an image with QR-encoded `invoice_url`
 
 
 ## Create Egress Invoice (User email flow)

--- a/source/includes/_ingress.md
+++ b/source/includes/_ingress.md
@@ -169,4 +169,4 @@ Field          | Type    | Description
 -------------- | ------- | -----------
 invoice_id     | String  | Internal **ON/RAMP**'s Invoice Identifier.
 invoice_url    | Url     | Url where to redirect user.
-invoice_url_qr | Url     | Url where to redirect user in QR code format.
+invoice_url_qr | Url     | Source Url for an image with QR-encoded `invoice_url`

--- a/source/includes/_ingress.md
+++ b/source/includes/_ingress.md
@@ -95,6 +95,7 @@ curl https://api.onramp.ltd/rpc/create_ingress_invoice                          
 ```json
 { "invoice_id": "62b570e8-9723-4287-a5a8-e825c2ffced2"
 , "invoice_url": "https://wallet.onramp.ltd/ingressing?reference=a3076265-138d-4be6-89fb-d50427adaf4e"
+, "invoice_url_qr": "https://api.onramp.ltd/qr_encode/68747470733a2f2f73746167652d77616c6c65742e6f6e72616d702e6c74642f656772657373696e673f7265666572656e63653d38303061343437382d393832322d343561382d616239302d323637306665393262343933"
 }
 ```
 
@@ -164,7 +165,8 @@ pausing the user payment and prompting manual intervention, potentially delaying
 
 ### Response JSON Fields
 
-Field       | Type    | Description
------------ | ------- | -----------
-invoice_id  | String  | Internal **ON/RAMP**'s Invoice Identifier.
-invoice_url | Url     | Url where to redirect user.
+Field          | Type    | Description
+-------------- | ------- | -----------
+invoice_id     | String  | Internal **ON/RAMP**'s Invoice Identifier.
+invoice_url    | Url     | Url where to redirect user.
+invoice_url_qr | Url     | Url where to redirect user in QR code format.


### PR DESCRIPTION
Quick PR adding the QR code field in responses of ingress and egress.

I also needed to updated the Dockerfile as it was not working for me. I got this:

```
Autoprefixer doesn’t support Node v4.8.2. Update it.
```

And so I update the Dockerfile with what was suggested here: https://stackoverflow.com/questions/52708521/autoprefixer-doesn-t-support-node-v4-8-2-update-it